### PR TITLE
Fix for issues #1 and #2

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -144,8 +144,12 @@ $watchjs$.defineProp(Object.prototype, "watchOne", function(prop, watcher) {
 
         obj.watchFunctions(prop);
 
-        if (JSON.stringify(oldval) != JSON.stringify(newval) && arguments.callee.caller != watcher) {
-            obj.callWatchers(prop);
+        if (JSON.stringify(oldval) != JSON.stringify(newval)) {
+            if (!$watchjs$.watcherInvocationRunning){
+                $watchjs$.watcherInvocationRunning = true;
+                obj.callWatchers(prop);
+                $watchjs$.watcherInvocationRunning = false;
+            }
         }
     };
 


### PR DESCRIPTION
Instead of using the problematic 'callee' I suggest to use a 'global' flag to detect if a watcher invocation is already running. 

It works nicely with 'use strict' and it doesn't get confused if the recursion had some intermediate methods.
