### PR TITLE
Extended callback to have paramaters

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -149,7 +149,7 @@ WatchJS.defineProp(Object.prototype, "watchOne", function(prop, watcher) {
 
         if (JSON.stringify(oldval) != JSON.stringify(newval)) {
             if (!WatchJS.noMore){
-                obj.callWatchers(prop);
+                obj.callWatchers(prop,newval,oldval);
                 WatchJS.noMore = false;
             }
         }
@@ -218,12 +218,12 @@ WatchJS.defineProp(Object.prototype, "unwatchOne", function(prop, watcher) {
     }
 });
 
-WatchJS.defineProp(Object.prototype, "callWatchers", function(prop) {
+WatchJS.defineProp(Object.prototype, "callWatchers", function(prop,newval,oldval) {
     var obj = this;
 
     for (var wr in obj.watchers[prop]) {
         if (WatchJS.isInt(wr)){
-            obj.watchers[prop][wr]();
+            obj.watchers[prop][wr](prop,newval,oldval);
         }
     }
 });


### PR DESCRIPTION
I saw your library, tried using it, and found I really couldn't get much info out of the callbacks as to what was happening.  I changed the callback signature to have three parameters with it when called

1st property that was changed
2nd the value it was changed to
3rd the value it was changed from

This is useful for databanding, knowing what changed in watchAll, and other use cases.
