### PR TITLE
Adds code to provide 'action' type to all watchers and value arguments to watchers of arrays

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -224,7 +224,7 @@
 
                 if (!WatchJS.noMore){
                     if (JSON.stringify(oldval) !== JSON.stringify(newval)) {
-                        callWatchers(obj, prop, newval, oldval);
+                        callWatchers(obj, prop, "set", newval, oldval);
                         WatchJS.noMore = false;
                     }
                 }
@@ -234,11 +234,11 @@
 
         };
 
-        callWatchers = function (obj, prop, newval, oldval) {
+        callWatchers = function (obj, prop, action, newval, oldval) {
 
             for (var wr in obj.watchers[prop]) {
                 if (isInt(wr)){
-                    obj.watchers[prop][wr].call(obj, prop, newval, oldval);
+                    obj.watchers[prop][wr].call(obj, prop, action, newval, oldval);
                 }
             }
         };
@@ -250,7 +250,7 @@
                 var response = original.apply(obj[prop], arguments);
                 watchOne(obj, obj[prop]);
                 if (methodName !== 'slice') {
-                    callWatchers(obj, prop);
+                    callWatchers(obj, prop, methodName,arguments);
                 }
                 return response;
             });
@@ -310,13 +310,13 @@
 
         };
 
-        callWatchers = function (obj, prop) {
+        callWatchers = function (obj, prop, action, value) {
 
             for (var i in subjects) {
                 var subj = subjects[i];
 
                 if (subj.obj == obj && subj.prop == prop) {
-                    subj.watcher.call(obj, prop);
+                    subj.watcher.call(obj, prop, action, value);
                 }
 
             }


### PR DESCRIPTION
Hi,
This code essentially addresses issue 24 https://github.com/melanke/Watch.JS/issues/24).
Now, watchers are passed the following arguments;

object watchers:
(property, action, newvalue, oldvalue)

array watchers:
(property, action, arguments)

``` javascript
For example, given this object:
var ex3 = {
    attr1: 0,
    attr2: "initial value of attr2",
    attr3: ["a", 3, null]
};

watch(ex3, function(arg1, arg2, arg3, arg4,){
    console.log("some attribute of ex3 changes:"+arg1+","+arg2+","+arg3+","+arg4);
});

ex3.attr3.push("new value");
ex3.attr2 = "new value";​​
```

Output:

> some attribute of ex3 changes:attr2,set,new value,initial value of attr2
> some attribute of ex3 changes:attr3,push,[object Arguments],undefined 

Notice that the action is always "set" for scalar properties and the name of the array function for array properties.
