### PR TITLE
Added checking for dirtyChecklist.length, and and change for loop for Ar...

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -686,12 +686,14 @@
         
         // start dirty check
         var n, value;
-        for(var i in dirtyChecklist) {
-            n = dirtyChecklist[i];
-            value = n.object[n.prop];
-            if (!compareValues(n.orig ,value)) {
-                n.orig = clone(value);
-                n.callback(value);
+        if (dirtyChecklist.length > 0) {
+            for (var i = 0; i < dirtyChecklist.length; i++) {
+                n = dirtyChecklist[i];
+                value = n.object[n.prop];
+                if (!compareValues(n.orig, value)) {
+                    n.orig = clone(value);
+                    n.callback(value);
+                }
             }
         }
 


### PR DESCRIPTION
Added checking for dirtyChecklist.length, and and change for loop for Array. Problem was, if you add Array.prototype.someFunction=function(){} watchjs will fail.

This related to https://github.com/melanke/Watch.JS/issues/83