### PR TITLE
Making unwatchOne more secure

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -576,15 +576,17 @@
     };
 
     var unwatchOne = function (obj, prop, watcher) {
-        if (watcher===undefined && obj.watchers[prop]) {
-            delete obj.watchers[prop]; // remove all property watchers
-        }
-        else {
-            for (var i=0; i<obj.watchers[prop].length; i++) {
-                var w = obj.watchers[prop][i];
-
-                if(w == watcher) {
-                    obj.watchers[prop].splice(i, 1);
+        if (obj.watchers[prop]) {
+            if (watcher===undefined) {
+                delete obj.watchers[prop]; // remove all property watchers
+            }
+            else {
+                for (var i=0; i<obj.watchers[prop].length; i++) {
+                    var w = obj.watchers[prop][i];
+    
+                    if (w == watcher) {
+                        obj.watchers[prop].splice(i, 1);
+                    }
                 }
             }
         }


### PR DESCRIPTION
In the unwatchOne function, test if a watcher exist for a given prop on obj. The test was previously only applied in the case no watcher parameter was given but it is also necessary when iterating over object watchers. This commit prevents unwatchOne to throw an error when it's called by the unwatchAll method (this error might only happen when dealing with nested objects).