### PR TITLE
Implement object-based unwatch

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -576,19 +576,24 @@
     };
 
     var unwatchOne = function (obj, prop, watcher) {
-        if (obj.watchers[prop]) {
-            if (watcher===undefined) {
-                delete obj.watchers[prop]; // remove all property watchers
-            }
-            else {
-                for (var i=0; i<obj.watchers[prop].length; i++) {
-                    var w = obj.watchers[prop][i];
-    
-                    if (w == watcher) {
-                        obj.watchers[prop].splice(i, 1);
+        if (prop) {
+            if (obj.watchers[prop]) {
+                if (watcher===undefined) {
+                    delete obj.watchers[prop]; // remove all property watchers
+                }
+                else {
+                    for (var i=0; i<obj.watchers[prop].length; i++) {
+                        var w = obj.watchers[prop][i];
+                        if (w == watcher) {
+                            obj.watchers[prop].splice(i, 1);
+                        }
                     }
                 }
             }
+        }
+        else
+        {
+            delete obj.watchers;
         }
         removeFromLengthSubjects(obj, prop, watcher);
         removeFromDirtyChecklist(obj, prop);
@@ -744,8 +749,12 @@
         for (var i=0; i<lengthsubjects.length; i++) {
             var subj = lengthsubjects[i];
 
-            if (subj.obj == obj && subj.prop == prop && subj.watcher == watcher) {
-                lengthsubjects.splice(i, 1);
+            if (subj.obj == obj) {
+                if (!prop || subj.prop == prop) {
+                    if (!watcher || subj.watcher == watcher) {
+                        lengthsubjects.splice(i, 1);
+                    }
+                }
             }
         }
 
@@ -758,9 +767,9 @@
             var watchers = n.object.watchers;
             notInUse = (
                 n.object == obj 
-                && n.prop == prop 
+                && (!prop || n.prop == prop)
                 && watchers
-                && ( !watchers[prop] || watchers[prop].length == 0 )
+                && (!prop || !watchers[prop] || watchers[prop].length == 0 )
             );
             if (notInUse)  {
                 dirtyChecklist.splice(i, 1);

--- a/src/watch.js
+++ b/src/watch.js
@@ -745,14 +745,18 @@
     };
 
     var removeFromLengthSubjects = function(obj, prop, watcher){
-
         for (var i=0; i<lengthsubjects.length; i++) {
             var subj = lengthsubjects[i];
 
             if (subj.obj == obj) {
                 if (!prop || subj.prop == prop) {
                     if (!watcher || subj.watcher == watcher) {
-                        lengthsubjects.splice(i, 1);
+                        // if we splice off one item at position i
+                        // we need to decrement i as the array is one item shorter
+                        // so when we increment i in the loop statement we
+                        // will land at the correct index.
+                        // if it's not decremented, you won't delete all length subjects
+                        lengthsubjects.splice(i--, 1);
                     }
                 }
             }
@@ -772,7 +776,8 @@
                 && (!prop || !watchers[prop] || watchers[prop].length == 0 )
             );
             if (notInUse)  {
-                dirtyChecklist.splice(i, 1);
+                // we use the same syntax as in removeFromLengthSubjects
+                dirtyChecklist.splice(i--, 1);
             }
         }
 


### PR DESCRIPTION
With this commit, it's possible to unwatch a whole object.
Previously you had to save the used watcher function.
Useful if you want to unregister all watchers from a given
object, but you have no access to all of them.

This fixes #38 