### PR TITLE
js require changed to "melanke-watchjs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ require("watch", function(WatchJS){
 #### Node.JS Require
 npm install melanke-watchjs
 ```javascript
-var WatchJS = require("watchjs")
+var WatchJS = require("melanke-watchjs")
 var watch = WatchJS.watch;
 var unwatch = WatchJS.unwatch;
 var callWatchers = WatchJS.callWatchers;


### PR DESCRIPTION
to match the npm install and package.json

(Because of previous commit regarding changed package name 7eb1bd6 by @melanke )