### PR TITLE
Fix comparing objects with undefined properties

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -76,7 +76,7 @@
             } else {
                 for(var i in a){
                     if (a.hasOwnProperty(i)) {
-                        if(b && b[i] === undefined) {
+                        if(b && !b.hasOwnProperty(i)) {
                             aplus.push(i);
                         }
                     }
@@ -90,7 +90,7 @@
             } else {
                 for(var j in b){
                     if (b.hasOwnProperty(j)) {
-                        if(a && a[j] === undefined) {
+                        if(a && !a.hasOwnProperty(j)) {
                             bplus.push(j);
                         }
                     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -71,6 +71,7 @@ QUnit.test("Observe the changes of all properties of the object", function( asse
     assert.expect(3);
     var done1 = assert.async();
     var obj = {
+        dummy: undefined,
         attr1: 1,
         attr2: 2,
         attr3: 3
@@ -285,6 +286,7 @@ QUnit.test("Observe new object properties", function( assert ) {
     assert.expect(4);
     var done1 = assert.async();
     var obj = {
+        dummy: undefined,
         attr1: 1,
         attr2: 2,
         attr3: 3
@@ -294,6 +296,7 @@ QUnit.test("Observe new object properties", function( assert ) {
     WatchJS.watch(obj, function(prop, action, newvalue, oldvalue){
         
         var oldObj = {
+            dummy: undefined,
             attr1: 1,
             attr2: 2,
             attr3: 3


### PR DESCRIPTION
When an object has an undefined property, the difference will always include this property in the added and removed property even if did not changed at all. this cause an endless loop

Adapted test to show the behavior