### PR TITLE
Change comparison of  datetime object to use its value instead of ref…

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -486,6 +486,10 @@
 
                 if (!WatchJS.noMore){ // this does not work with Object.observe
                     //if (JSON.stringify(oldval) !== JSON.stringify(newval)) {
+                    if (obj[prop] instanceof Date) {
+                        oldval = oldval.valueOf();
+                        newval = newval.valueOf();
+                    }	
                     if (oldval !== newval) {
                         if (!delayWatcher) {
                             callWatchers(obj, prop, "set", newval, oldval);


### PR DESCRIPTION
We found an issue in our project when watch a property of DateTime type. The current code is comparing the reference of the DateTime object instead of its value. It will mark the property dirty after update it with a DateTime object which has the same DateTime value as before update . The change here is to compare the DateTime type with its value instead of reference.